### PR TITLE
Treat DMs correctly in MessageFormComponent

### DIFF
--- a/src/components/slack/form/message.component.ts
+++ b/src/components/slack/form/message.component.ts
@@ -3,7 +3,7 @@ import { NgForm } from '@angular/forms'; // tslint:disable-line
 import * as $ from 'jquery';
 import '../../../jquery.textcomplete.js';
 import { EmojiService } from '../../../services/slack/slack.service';
-import { Channel, DataStore } from '../../../services/slack/slack.types';
+import { Channel, DM, DataStore } from '../../../services/slack/slack.types';
 
 @Component({
     selector: 'ss-messageform',
@@ -14,7 +14,7 @@ export class MessageFormComponent implements OnChanges {
     @Output() submit = new EventEmitter<string>();
     @Output() close = new EventEmitter();
 
-    @Input() channel: Channel;
+    @Input() channelLikeID: string;
     @Input() dataStore: DataStore;
 
     @Input() teamID: string = '';
@@ -22,17 +22,29 @@ export class MessageFormComponent implements OnChanges {
     @Input() extraInfo: string = '';
     @Input() emoji: EmojiService;
 
+    get channel(): Channel {
+        return this.dataStore.getChannelById(this.channelLikeID);
+    }
+
+    get dm(): DM {
+        return this.dataStore.getDMById(this.channelLikeID);
+    }
+
     get channelName(): string {
-        return this.channel.name;
+        if(this.channel)
+            return this.channel.name;
+        else
+            return "DM_" + this.dataStore.getUserById(this.dm.user).name;
     }
 
     get channelID(): string {
-        return this.channel.id;
+        return this.channelLikeID;
     }
 
     ngOnChanges(): void {
         const emojis = this.emoji.allEmojis;
-        const users = this.channel.members.map(m => this.dataStore.getUserById(m).name);
+        const users = (this.channel ? this.channel.members.map(m => this.dataStore.getUserById(m).name) : []);
+
         $('#slack_message_input').textcomplete('destroy');
         $('#slack_message_input').textcomplete([
             { // emojis

--- a/src/components/slack/list/slacklist.component.html
+++ b/src/components/slack/list/slacklist.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="showForm" class="message-form">
     <ss-messageform
-        [channel]="submitContext.channel"
+        [channelLikeID]="submitContext.channelLikeID"
         [dataStore]="submitContext.dataStore"
         [teamID]="submitContext.teamID"
         [initialText]="submitContext.initialText"

--- a/src/components/slack/list/slacklist.component.ts
+++ b/src/components/slack/list/slacklist.component.ts
@@ -107,7 +107,7 @@ export class DisplaySlackMessageInfo {
 }
 
 interface SubmitContext {
-    channel: Channel;
+    channelLikeID: string;
     dataStore: DataStore;
     teamID: string;
 
@@ -122,7 +122,7 @@ interface SubmitContext {
 class PostMessageContext implements SubmitContext {
     constructor(
         public client: SlackService,
-        public channel: Channel,
+        public channelLikeID: string,
         public teamID: string,
         public infos: DisplaySlackMessageInfo[],
     ) {
@@ -138,7 +138,7 @@ class PostMessageContext implements SubmitContext {
 
     get lastMessageTs(): string {
         for (let i = 0; i < this.infos.length; i++) {
-            if (this.infos[i].message.channelID === this.channel.id) {
+            if (this.infos[i].message.channelID === this.channelLikeID) {
                 return this.infos[i].message.ts;
             }
         }
@@ -156,12 +156,12 @@ class PostMessageContext implements SubmitContext {
     async submit(text: string): Promise<any> {
         if (text.trim().match(/^\+:(.*):$/)) {
             let reaction = text.trim().match(/^\+:(.*):$/)[1];
-            this.client.addReaction(reaction, this.channel.id, this.lastMessageTs);
+            this.client.addReaction(reaction, this.channelLikeID, this.lastMessageTs);
         } else if (text.trim().match(/^\-:(.*):$/)) {
             let reaction = text.trim().match(/^\-:(.*):$/)[1];
-            this.client.removeReaction(reaction, this.channel.id, this.lastMessageTs);
+            this.client.removeReaction(reaction, this.channelLikeID, this.lastMessageTs);
         } else {
-            return this.client.postMessage(this.channel.id, text);
+            return this.client.postMessage(this.channelLikeID, text);
         }
     }
 }
@@ -181,8 +181,8 @@ class EditMessageContext implements SubmitContext {
         return this.client.emoji;
     }
 
-    get channel(): Channel {
-        return this.message.channel;
+    get channelLikeID(): string {
+        return this.message.channelID;
     }
 
     get channelName(): string {
@@ -405,7 +405,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
     onClickWrite(info: DisplaySlackMessageInfo) {
         this.submitContext = new PostMessageContext(
             info.client,
-            info.message.channel,
+            info.message.channelID,
             info.message.teamID,
             this.messages
         );
@@ -459,7 +459,7 @@ export class SlackListComponent implements OnInit, OnDestroy {
                 var message = messages[0];
                 this.submitContext = new PostMessageContext(
                     message.client,
-                    message.message.channel,
+                    message.message.channelID,
                     message.message.teamID,
                     messages
                 );


### PR DESCRIPTION
When the write or the edit button associated with a DM is clicked, the `channel` input to `MessageFormComponent` becomes `undefined` in the current implementation and causes various inconsistencies.

The root cause of this confusion is that Slack gives `channelID` to both a DM and a normal message, but calling `DataStore.getChannelByID()` for a DM's `channelID` returns `undefined`.

This PR makes it clear that `channelID` is not necessarily the ID of a channel by introducing a name  `channelLikeID`, meaning that it looks like a channel from the user's view point but it is not necessarily a channel and might also be a DM (handled in this fix) or a group (still ignored).

I confirmed that posting, editing, and deleting a DM and a normal message all work after applying this PR.

Before:
![before](https://cloud.githubusercontent.com/assets/11990836/26762364/de28375a-497b-11e7-9a33-142e334afed7.png)

After:
![after](https://cloud.githubusercontent.com/assets/11990836/26762365/dfc74efc-497b-11e7-9072-8dabef610f2a.png)
