### PR TITLE
Handle rejected promise so that the submit form does not freeze on error

### DIFF
--- a/src/components/slack/list/slacklist.component.ts
+++ b/src/components/slack/list/slacklist.component.ts
@@ -470,28 +470,18 @@ export class SlackListComponent implements OnInit, OnDestroy {
         this.detector.detectChanges();
     }
 
-    enableSubmitForm(){
-        this.submitting = false;
-        this.submitContext = null;
-        this.detector.detectChanges();
-    }
-
     async submitForm(text: string) {
         if (this.submitContext != null) {
             this.submitting = true;
             this.detector.detectChanges();
 
-            this.submitContext.submit(text).then(
-                // everyting went well
-                () => {
-                    this.enableSubmitForm();
-                },
-                // slack server may have returned an error. print the error and re-enable the submit form anyway
-                (reason) => {
-                    console.log(reason);
-                    this.enableSubmitForm();
-                }
-            );
+            await this.submitContext.submit(text).catch(
+                // slack server may have returned an error. print the error and continue
+                (e) => { console.log(e); });
+
+            this.submitting = false;
+            this.submitContext = null;
+            this.detector.detectChanges();
         }
     }
 

--- a/src/components/slack/list/slacklist.component.ts
+++ b/src/components/slack/list/slacklist.component.ts
@@ -470,16 +470,28 @@ export class SlackListComponent implements OnInit, OnDestroy {
         this.detector.detectChanges();
     }
 
+    enableSubmitForm(){
+        this.submitting = false;
+        this.submitContext = null;
+        this.detector.detectChanges();
+    }
+
     async submitForm(text: string) {
         if (this.submitContext != null) {
             this.submitting = true;
             this.detector.detectChanges();
 
-            await this.submitContext.submit(text);
-
-            this.submitting = false;
-            this.submitContext = null;
-            this.detector.detectChanges();
+            this.submitContext.submit(text).then(
+                // everyting went well
+                () => {
+                    this.enableSubmitForm();
+                },
+                // slack server may have returned an error. print the error and re-enable the submit form anyway
+                (reason) => {
+                    console.log(reason);
+                    this.enableSubmitForm();
+                }
+            );
         }
     }
 


### PR DESCRIPTION
The current implementation `await` until `submitContext.submit` is resolved. However, it is sometimes rejected and the following code to enabled the submit form is never executed in this case and thus the submit form freezes forever.

For example, when a reaction that is already added to the latest message is sent by ASS (by submitting `+:something:` twice), the slack server returns an error and the submit form will never work thereafter.