### PR TITLE
Escape < and >

### DIFF
--- a/src/components/slack/form/message.component.ts
+++ b/src/components/slack/form/message.component.ts
@@ -91,7 +91,7 @@ export class MessageFormComponent implements OnChanges {
     onKeyPress(event: KeyboardEvent, textArea: any): void {
         if (event.key === 'Enter') {
             if (!event.altKey) {
-                this.onSubmit(textArea.value);
+                this.onSubmit(textArea.value.replace(/[<>]/g, (c: string) => {return c == "<" ? "&lt;" : "&gt;"}));
                 event.preventDefault();
             } else {
                 textArea.value += '\n';


### PR DESCRIPTION
In the official Slack client, escaping `<` and `>`  seems to happen either in the client-side or in the server-side depending on what the actual message looks like.

This PR makes ASS escape `<` and `>` in every case, which might be an over-kill (for example HTML tags are automatically escaped in the server-side even without this PR), but it is safe in the sense that it does not break anything.