### PR TITLE
Add various breaking line methods.

### DIFF
--- a/src/components/slack/form/message.component.html
+++ b/src/components/slack/form/message.component.html
@@ -11,7 +11,7 @@
         wrap="soft"
         rows="3"
         id="slack_message_input"
-        (keypress)="onKeyPress($event, textArea)"
+        (keydown)="onKeyDown($event, textArea)"
         (keyup)="onKeyUp($event)"
         [autofocus]
         [value]="initialText"

--- a/src/components/slack/form/message.component.ts
+++ b/src/components/slack/form/message.component.ts
@@ -88,9 +88,9 @@ export class MessageFormComponent implements OnChanges {
         }
     }
 
-    onKeyPress(event: KeyboardEvent, textArea: any): void {
+    onKeyDown(event: KeyboardEvent, textArea: any): void {
         if (event.key === 'Enter') {
-            if (!event.altKey) {
+            if (!event.altKey && !event.shiftKey && !event.ctrlKey) {
                 this.onSubmit(textArea.value.replace(/[<>&]/g,
                                                      (c: string) => {
                                                          if(c == '&')
@@ -102,7 +102,9 @@ export class MessageFormComponent implements OnChanges {
                                                      }));
                 event.preventDefault();
             } else {
-                textArea.value += '\n';
+                if (!event.shiftKey) {
+                    textArea.value += '\n';
+                }
             }
         }
     }

--- a/src/components/slack/form/message.component.ts
+++ b/src/components/slack/form/message.component.ts
@@ -100,12 +100,10 @@ export class MessageFormComponent implements OnChanges {
                                                          else
                                                              return '&gt;';
                                                      }));
-                event.preventDefault();
             } else {
-                if (!event.shiftKey) {
-                    textArea.value += '\n';
-                }
+                textArea.value += '\n';
             }
+            event.preventDefault();
         }
     }
 


### PR DESCRIPTION
KeyPress event isn't working correctly in Windows. So I changed it to KeyDown event. It is working well now.

When I broke the line by Shift+Enter, ASS added the '\n' twice. So I excepted to add '\n' manually in this case.