### PR TITLE
Do not hook enter during auto-completion

### DIFF
--- a/src/components/slack/form/message.component.ts
+++ b/src/components/slack/form/message.component.ts
@@ -119,7 +119,7 @@ export class MessageFormComponent implements OnChanges {
     }
 
     handleEnter(event: KeyboardEvent, textArea: any): void {
-        if (event.key === 'Enter') {
+        if (event.key === 'Enter' && $('.textcomplete-dropdown').css("display") == "none") {
             if (!event.altKey && !event.shiftKey && !event.ctrlKey) {
                 this.onSubmit(textArea.value.replace(/[<>&]/g,
                                                      (c: string) => {


### PR DESCRIPTION
The current version inserts a newline when enter is hit even during auto-completion, but the expected behavior is to select auto-completed item under the cursor.