### PR TITLE
Use RTMClient's teamID

### DIFF
--- a/src/services/slack/slack.service.ts
+++ b/src/services/slack/slack.service.ts
@@ -13,7 +13,7 @@ import { SlackUtil } from './slack-util';
 import * as emojione from 'emojione';
 
 export class SlackMessage {
-    constructor(public message: RTMMessage, public dataStore: DataStore, public myUserId: string) {
+    constructor(public message: RTMMessage, public dataStore: DataStore, public teamID: string, public myUserId: string) {
     }
 
     get text(): string {
@@ -51,10 +51,6 @@ export class SlackMessage {
 
     get teamThumbnail(): string {
         return this.team ? this.team.icon.image_68 : '';
-    }
-
-    get teamID(): string {
-        return this.message.team_id || this.message.source_team || this.message.team || '';
     }
 
     get channel(): Channel {

--- a/src/services/slack/wrapper/rtmwrapper.ts
+++ b/src/services/slack/wrapper/rtmwrapper.ts
@@ -7,6 +7,7 @@ export class RTMClientWrapper {
     messages = new Subject<SlackMessage>();
     reactionAdded = new Subject<SlackReactionAdded>();
     reactionRemoved = new Subject<SlackReactionRemoved>();
+    teamID: string;
 
     client: any;
     get dataStore(): DataStore {
@@ -17,10 +18,11 @@ export class RTMClientWrapper {
         this.client = new RtmClient(token, { logLevel: 'debug' }, new MemoryDataStore());
         this.client.on(CLIENT_EVENTS.RTM.AUTHENTICATED, (rtmStartData) => {
             console.log(`start ${this.token} ${rtmStartData}`);
+            this.teamID = rtmStartData.team.id;
         });
 
         this.client.on(RTM_EVENTS.MESSAGE, (message: RTMMessage) => {
-            this.messages.next(new SlackMessage(message, this.client.dataStore as DataStore, this.client.activeUserId));
+            this.messages.next(new SlackMessage(message, this.client.dataStore as DataStore, this.teamID, this.client.activeUserId));
         });
 
         this.client.on(RTM_EVENTS.REACTION_ADDED, (reaction: RTMReactionAdded) => {


### PR DESCRIPTION
Use RTMClient's teamID to avoid the situation we cannot detect team by the message sent.

Fix #55 