### PR TITLE
Parse channel without channel name like <#ABCDEFG> correctly, and use…

### DIFF
--- a/src/components/slack/list/submit-context.ts
+++ b/src/components/slack/list/submit-context.ts
@@ -2,6 +2,7 @@ import { SlackMessage, SlackClient } from '../../../services/slack/slack-client'
 import { DataStore } from '../../../services/slack/slack.types';
 import { EmojiService } from '../../../services/slack/emoji.service';
 import { DisplaySlackMessageInfo } from '../../../services/slack/slack.service';
+import { SlackUtil } from '../../../services/slack/slack-util';
 
 export interface SubmitContext {
     channelLikeID: string;
@@ -117,20 +118,7 @@ export class EditMessageContext implements SubmitContext {
     get initialText(): string {
         const messageText = this.message.text;
         return messageText.replace(/<([^>]+)>/g, (value: string) => {
-            value = value.substr(1, value.length - 2);
-            const bar = value.indexOf('|');
-            if (bar >= 0) {
-                // Channel: <#XXYYZZ|channel>  =>  #channel
-                if (value[0] === '#') {
-                    return '#' + value.substr(bar + 1);
-                    // Url with no 'http': <http://github.com|github.com>  =>  github.com
-                } else {
-                    return value.substr(bar + 1);
-                }
-            } else {
-                // Full url: <https://github.com>  =>  https://github.com
-                return value;
-            }
+            return SlackUtil.parseLink(value, this.client.dataStore).text;
         }).replace(/&amp;/g, '&').replace(/&lt;/g, '<').replace(/&gt;/g, '>');
     }
 

--- a/src/services/slack/slack-parser.service.ts
+++ b/src/services/slack/slack-parser.service.ts
@@ -30,49 +30,8 @@ export class MarkDownParser implements SlackParser {
 export class LinkParser implements SlackParser {
     parse(text: string, dataStore: DataStore): string {
         return text.replace(/<([^>]+)>/g, (value: string) => {
-            value = value.substr(1, value.length - 2);
-            const bar = value.indexOf('|');
-            if (bar >= 0) {
-                const text1 = value.substr(0, bar);
-                const text2 = value.substr(bar + 1);
-                return this.parse2(text1, text2, dataStore);
-            } else {
-                return this.parse1(value, dataStore);
-            }
+            return SlackUtil.parseLink(value, dataStore).withLink;
         });
-    }
-
-    parse1(text: string, dataStore: DataStore): string {
-        if (text[0] === '@' || text[0] === '!') {
-            const user = dataStore.getUserById(text.substr(1));
-            if (user) {
-                return `@${user.name}`;
-            }
-            const bot = dataStore.getBotById(text.substr(1));
-            if (bot) {
-                return `@${bot.name}`;
-            }
-            return '@' + text.substr(1);
-        } else {
-            return `<a href="${text}">${text}</a>`;
-        }
-    }
-
-    parse2(text1: string, text2: string, dataStore: DataStore): string {
-        if (text1[0] === '#') {
-            const channel = dataStore.getChannelById(text1.substr(1));
-            const color = SlackUtil.channelColor(channel.name);
-            // <ss-channelname> does not work...
-            return `<span class="channel-name" style="color: ${color};">#${text2}</span>`;
-        } else if (text1[0] === '@' || text1[0] === '!') {
-            if (text2[0] === '@') {
-                return text2;
-            } else {
-                return `@${text2}`;
-            }
-        } else {
-            return `<a href="${text1}">${text2}</a>`;
-        }
     }
 }
 

--- a/src/services/slack/slack-util.ts
+++ b/src/services/slack/slack-util.ts
@@ -1,6 +1,15 @@
 import { DataStore } from './slack.types';
 import * as seedrandom from 'seedrandom';
 
+export class ParseLinkResult {
+    get withLink(): string {
+        return this._withLink ? this._withLink : this.text;
+    }
+
+    constructor(public text: string, public _withLink: string = undefined) {
+    }
+}
+
 export class SlackUtil {
     static channelColor(channelName: string): string {
         let res = '#';
@@ -42,5 +51,57 @@ export class SlackUtil {
         }
 
         return '???';
+    }
+
+    static parseLink(text: string, dataStore: DataStore): ParseLinkResult {
+        text = text.substr(1, text.length - 2);
+        const bar = text.indexOf('|');
+        if (bar >= 0) {
+            const text1 = text.substr(0, bar);
+            const text2 = text.substr(bar + 1);
+            return this.parseLink2(text1, text2, dataStore);
+        } else {
+            return this.parseLink1(text, dataStore);
+        }
+    }
+
+    static parseLink1(text: string, dataStore: DataStore): ParseLinkResult {
+        if (text[0] === '@' || text[0] === '!') {
+            const user = dataStore.getUserById(text.substr(1));
+            if (user) {
+                return new ParseLinkResult(`@${user.name}`);
+            }
+            const bot = dataStore.getBotById(text.substr(1));
+            if (bot) {
+                return new ParseLinkResult(`@${bot.name}`);
+            }
+            return new ParseLinkResult('@' + text.substr(1));
+        } else if (text[0] === '#') {
+            const channel = dataStore.getChannelById(text[0].substr(1));
+            const color = SlackUtil.channelColor(channel.name);
+            // <ss-channelname> does not work...
+            const withLink = `<span class="channel-name" style="color: ${color};">#${channel.name}</span>`;
+            return new ParseLinkResult('#' + channel.name, withLink);
+        } else {
+            return new ParseLinkResult(text);
+        }
+    }
+
+    static parseLink2(text1: string, text2: string, dataStore: DataStore): ParseLinkResult {
+        if (text1[0] === '#') {
+            const channel = dataStore.getChannelById(text1.substr(1));
+            const color = SlackUtil.channelColor(channel.name);
+            // <ss-channelname> does not work...
+            const withLink = `<span class="channel-name" style="color: ${color};">#${text2}</span>`;
+            return new ParseLinkResult('#' + text2, withLink);
+        } else if (text1[0] === '@' || text1[0] === '!') {
+            if (text2[0] === '@') {
+                return new ParseLinkResult(text2);
+            } else {
+                return new ParseLinkResult(`@${text2}`);
+            }
+        } else {
+            return new ParseLinkResult(text2, `<a href="${text1}">${text2}</a>`);
+        }
     }
 }


### PR DESCRIPTION
… common code to restore original plain text in edit mode.

Fix #71 